### PR TITLE
Aanpassingen voor nieuwe Twente Milieu website

### DIFF
--- a/classes/twente_milieu.php
+++ b/classes/twente_milieu.php
@@ -97,7 +97,7 @@ class TwenteMilieu {
       case 10:
         return "Verpakkingen worden opgehaald";
       default:
-        return "Onbekend verpakkingstype wordt opgehaald";
+        return "Onbekend afvaltype wordt opgehaald";
     }
   }
 

--- a/classes/twente_milieu.php
+++ b/classes/twente_milieu.php
@@ -40,7 +40,8 @@ class TwenteMilieu {
 
   public function getEvents($from_date) {
     // Do requests for the coming three months
-    $to_date = new DateTime($from_date->format('Y'), $from_date->format('m') + 2, 1);
+    $to_date = new DateTime();
+    $to_date->setDate($from_date->format('Y'), $from_date->format('m') + 3, 1);
     return $this->getCalendar($from_date, $to_date);
   }
 
@@ -77,7 +78,7 @@ class TwenteMilieu {
       foreach( $trash_type->pickupDates as $date ) {
         $events[] = array(
           'date'    => new DateTime($date),
-          'summary' => $self->getTrashSummary($trash_type->pickupType)
+          'summary' => $this->getTrashSummary($trash_type->pickupType)
         );
       }
     }


### PR DESCRIPTION
Twente Milieu heeft een nieuwe website sinds een paar maanden. En die sloopte natuurlijk de iCal feed. Maar de nieuwe website maakt gebruikt van een JSON API voor de afvalkalender, dus eigenlijk hebben ze het ons een stuk makkelijker gemaakt.

Ik doe hier de aanname dat de `companyCode` een code is die specifiek is voor Twente Milieu bij de service `wasteapi.2go-mobile.com`. Works for me 😉 